### PR TITLE
test: fix index require

### DIFF
--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { Snowflake } from '../index'
+import { Snowflake } from '../index.js'
 
 test('generate id', (t) => {
   const snow = new Snowflake(1, 1);


### PR DESCRIPTION
i686-pc-windows can not use require('index')